### PR TITLE
Set default values to user model

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -34,13 +34,13 @@ class User extends Model
     protected $isBlocked;
 
     /** @var bool */
-    protected $disableHescoreGUIAccess;
+    protected $disableHescoreGUIAccess = false;
 
     /** @var bool */
-    protected $hasProductionAccess;
+    protected $hasProductionAccess = true;
 
     /** @var bool */
-    protected $hasSandboxAccess;
+    protected $hasSandboxAccess = false;
 
     /** @var \DateTime */
     protected $created;


### PR DESCRIPTION
I am adding default values to the user model; the "add new" features were failing against the getter methods failing when returning NULL.  This will resolve the issue, and also allow for us to pull defaults from the user model rather than set them manually throughout our forms and UI code.