### PR TITLE
Check if production env for email sending

### DIFF
--- a/src/Helpers/EmailHelper.php
+++ b/src/Helpers/EmailHelper.php
@@ -31,7 +31,25 @@ class EmailHelper extends Helper
         if($message === null) {
             $email->setMessage('Test Email');
         }
-        
+
+        if(env('APP_ENV') === 'production') {
+            return $email->send();
+        } else {
+            return EmailHelper::sendInTestEnvironment($email);
+        }
+    }
+
+    /**
+     * Sends the email with header to the dev team 
+     * @param Email $email The email to send
+     * @return bool
+     */
+    private static function sendInTestEnvironment(Email $email)
+    {
+        $header = $email->createHeader();
+        $email->setMessage($header."\n\n".$email->getMessage());
+        $email->clearAllRecipients();
+        $email->setRecipient(Email::HES_DEV_TEAM_EMAIL);
         return $email->send();
     }
 }


### PR DESCRIPTION
Moved the production check to our sendEmail method.  If we are not in a production environment, it send the email, with headers appended to the message, to the dev team.