### PR TITLE
Refactor getSoapClient to remove static variable

### DIFF
--- a/src/Services/HesSoapApiService.php
+++ b/src/Services/HesSoapApiService.php
@@ -150,16 +150,10 @@ abstract class HesSoapApiService
      */
     public function getSoapClient()
     {
-        static $soapClient;
-
-        if (!$soapClient) {
-            $soapClient = new \SoapClient($this->soapApiWsdlUri, [
-                'trace' => true, // Enables __getLastResponse(), which we use because it allows us to more easily pass a response back out from the LBNL API
-                'exceptions' => true
-            ]);
-        }
-
-        return $soapClient;
+        return new \SoapClient($this->soapApiWsdlUri, [
+            'trace' => true, // Enables __getLastResponse(), which we use because it allows us to more easily pass a response back out from the LBNL API
+            'exceptions' => true
+        ]);
     }
 
     /**


### PR DESCRIPTION
Refactor getSoapClient method to always create a new SoapClient instance.